### PR TITLE
tango-idl must be deployed to bintray

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,3 +17,4 @@ configure_file(tangoidl.pc.cmake tangoidl.pc @ONLY)
 install(FILES "${CMAKE_CURRENT_BINARY_DIR}/tangoidl.pc"
 DESTINATION "${CMAKE_INSTALL_FULL_LIBDIR}/pkgconfig")
 
+#TODO deploy to bintray


### PR DESCRIPTION
In this case developers will be able to get it from repository (debian|ubuntu) rather than build it from source