### PR TITLE
Generate and compile java classes from idl and add them to the maven …

### DIFF
--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,0 +1,2 @@
+# Default ignored files
+/workspace.xml

--- a/.idea/compiler.xml
+++ b/.idea/compiler.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="CompilerConfiguration">
+    <annotationProcessing>
+      <profile name="Maven default annotation processors profile" enabled="true">
+        <sourceOutputDir name="target/generated-sources/annotations" />
+        <sourceTestOutputDir name="target/generated-test-sources/test-annotations" />
+        <outputRelativeToContentRoot value="true" />
+        <module name="tango-idl" />
+      </profile>
+    </annotationProcessing>
+    <bytecodeTargetLevel>
+      <module name="tango-idl" target="1.5" />
+    </bytecodeTargetLevel>
+  </component>
+</project>

--- a/pom.xml
+++ b/pom.xml
@@ -8,8 +8,10 @@
     <packaging>jar</packaging>
 
     <name>${project.artifactId}</name>
-    <description>TANGO interface defined in IDL</description>
+    <description>TANGO interface defined in IDL and compiled with jacorb IDL compiler</description>
     <url>https://github.com/tango-controls/tango-idl</url>
+    <inceptionYear>2004</inceptionYear>
+
 
     <issueManagement>
         <system>GitHub</system>
@@ -29,9 +31,34 @@
 
     <developers>
         <developer>
+            <id>verdier</id>
+            <name>Pascal Verdier</name>
+            <email>verdier@esrf.fr</email>
+            <organization>ESRF</organization>
+            <organizationUrl>http://www.ersf.eu</organizationUrl>
+            <roles>
+                <role>Developer</role>
+            </roles>
+            <timezone>1</timezone>
+        </developer>
+        <developer>
+            <id>abeille</id>
+            <name>Gwenaëlle Abeillé</name>
+            <email>gwenaelle.abeille@synchrotron-soleil.fr</email>
+            <organization>Synchrotron Soleil</organization>
+            <organizationUrl>http://www.synchrotron-soleil.fr</organizationUrl>
+            <roles>
+                <role>Integrator, Developer</role>
+            </roles>
+            <timezone>1</timezone>
+        </developer>
+        <developer>
             <id>ingvord</id>
             <name>Igor Khokhriakov</name>
             <email>mail@ingvord.ru</email>
+            <roles>
+                <role>Integrator</role>
+            </roles>
         </developer>
     </developers>
 
@@ -44,11 +71,22 @@
     <distributionManagement>
       <repository>
           <id>bintray-tango-controls</id>
-          <url>https://api.bintray.com/maven/tango-controls/maven/${project.artifactId}/;publish=1</url>
+          <url>https://api.bintray.com/maven/tango-controls/jtango/${project.artifactId}/;publish=1</url>
       </repository>
     </distributionManagement>
 
     <dependencies>
+        <dependency>
+            <groupId>org.jacorb</groupId>
+            <artifactId>jacorb-omgapi</artifactId>
+            <version>3.8</version>
+        </dependency>
+        <dependency>
+            <groupId>org.jacorb</groupId>
+            <artifactId>jacorb-idl-compiler</artifactId>
+            <version>3.8</version>
+            <scope>compile</scope>
+        </dependency>
     </dependencies>
 
     <build>
@@ -60,6 +98,73 @@
                 </includes>
             </resource>
         </resources>
+        <plugins>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>idlj-maven-plugin</artifactId>
+                <version>1.2.2</version>
+                <executions>
+                    <execution>
+                        <id>compile-tango-idl</id>
+                        <phase>generate-sources</phase>
+                        <goals>
+                            <goal>generate</goal>
+                        </goals>
+                        <configuration>
+                            <debug>true</debug>
+                            <compiler>jacorb</compiler>
+                            <sources>
+                                <source>
+                                    <additionalArguments>
+                                        <additionalArgument>-notimestamps</additionalArgument>
+                                        <additionalArgument>-nofinal</additionalArgument>
+                                    </additionalArguments>
+                                    <packagePrefix>fr.esrf</packagePrefix>
+                                    <includes>
+                                        <include>tango.idl</include>
+                                    </includes>
+                                    <emitStubs>true</emitStubs>
+                                    <emitSkeletons>true</emitSkeletons>
+                                </source>
+                            </sources>
+                            <sourceDirectory>${project.basedir}</sourceDirectory>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <artifactId>maven-jar-plugin</artifactId>
+                <version>3.1.2</version>
+                <configuration>
+                    <forceCreation>true</forceCreation>
+                </configuration>
+            </plugin>
+            <plugin>
+                <artifactId>maven-source-plugin</artifactId>
+                <version>3.1.0</version>
+                <executions>
+                    <execution>
+                        <id>attach-sources</id>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-javadoc-plugin</artifactId>
+                <version>3.1.0</version>
+                <executions>
+                    <execution>
+                        <id>attach-javadocs</id>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
     </build>
 
     <repositories>

--- a/pom.xml
+++ b/pom.xml
@@ -3,11 +3,16 @@
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>org.tango-controls</groupId>
-    <artifactId>tango-idl</artifactId>
+    <artifactId>tango-idl-java</artifactId>
     <version>5</version>
     <packaging>jar</packaging>
 
-    <name>${project.artifactId}</name>
+    <properties>
+        <project.scm.name>tango-idl</project.scm.name>
+        <jacorb.ver>3.8</jacorb.ver>
+    </properties>
+
+    <name>${project.scm.name}</name>
     <description>TANGO interface defined in IDL and compiled with jacorb IDL compiler</description>
     <url>https://github.com/tango-controls/tango-idl</url>
     <inceptionYear>2004</inceptionYear>
@@ -63,9 +68,9 @@
     </developers>
 
     <scm>
-        <connection>scm:git:git@github.com:tango-controls/${project.artifactId}</connection>
-        <developerConnection>scm:git:git@github.com:tango-controls/${project.artifactId}</developerConnection>
-        <url>https://github.com/tango-controls/${project.artifactId}</url>
+        <connection>scm:git:git@github.com:tango-controls/${project.scm.name}</connection>
+        <developerConnection>scm:git:git@github.com:tango-controls/${project.scm.name}</developerConnection>
+        <url>https://github.com/tango-controls/${project.scm.name}</url>
     </scm>
 
     <distributionManagement>
@@ -79,12 +84,12 @@
         <dependency>
             <groupId>org.jacorb</groupId>
             <artifactId>jacorb-omgapi</artifactId>
-            <version>3.8</version>
+            <version>${jacorb.ver}</version>
         </dependency>
         <dependency>
             <groupId>org.jacorb</groupId>
             <artifactId>jacorb-idl-compiler</artifactId>
-            <version>3.8</version>
+            <version>${jacorb.ver}</version>
             <scope>compile</scope>
         </dependency>
     </dependencies>

--- a/tango-idl.iml
+++ b/tango-idl.iml
@@ -4,9 +4,15 @@
     <output url="file://$MODULE_DIR$/target/classes" />
     <output-test url="file://$MODULE_DIR$/target/test-classes" />
     <content url="file://$MODULE_DIR$">
+      <sourceFolder url="file://$MODULE_DIR$/target/generated-sources/idl" isTestSource="false" generated="true" />
       <excludeFolder url="file://$MODULE_DIR$/target" />
     </content>
     <orderEntry type="inheritedJdk" />
     <orderEntry type="sourceFolder" forTests="false" />
+    <orderEntry type="library" name="Maven: org.jacorb:jacorb-omgapi:3.8" level="project" />
+    <orderEntry type="library" name="Maven: org.jacorb:jacorb-idl-compiler:3.8" level="project" />
+    <orderEntry type="library" name="Maven: org.apache.ant:ant:1.8.2" level="project" />
+    <orderEntry type="library" name="Maven: org.apache.ant:ant-launcher:1.8.2" level="project" />
+    <orderEntry type="library" name="Maven: java_cup:java_cup:0.9e" level="project" />
   </component>
 </module>


### PR DESCRIPTION
…artifact. See [tango-controls/JTango#69](https://github.com/tango-controls/JTango/issues/69)

Maven artifact is deployed to bintray.com/tango-controls/jtango instead of bintray.com/tango-controls/maven. 

This one now replaces JTangoIDL